### PR TITLE
Changed Name for VM template variable name.

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -6,7 +6,7 @@ variable "vmnamesuffix" {
   description = "vmname suffix after numbered index coming from instance variable"
   default = ""
 }
-variable "vmtemp" {
+variable "vmtemplate_name" {
   description = "Name of the template available in the vSphere"
 }
 variable "is_windows_image" {


### PR DESCRIPTION
The vmtemp variable for some people or context can be confused with a temporal VM name. Just to ensure people always put the template name, I suggest changing its name to this new one.